### PR TITLE
Add input completion status tracking for event participants

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -7,6 +7,12 @@ export async function createEvent(title?: string) {
   return await createEventService(title);
 }
 
-export async function updateParticipant(eventId: string, userId: string, ngDates: string[], name?: string) {
-  return await updateParticipantService(eventId, userId, ngDates, name);
+export async function updateParticipant(
+  eventId: string,
+  userId: string,
+  ngDates: string[],
+  name?: string,
+  inputCompleted?: boolean,
+) {
+  return await updateParticipantService(eventId, userId, ngDates, name, inputCompleted);
 }

--- a/src/components/event/Calendar.tsx
+++ b/src/components/event/Calendar.tsx
@@ -2,6 +2,7 @@ import { CalendarNavigation } from "./CalendarNavigation";
 import { CalendarGrid } from "./CalendarGrid";
 import { CalendarStatus } from "./CalendarStatus";
 import { ParticipantNameInput } from "./ParticipantNameInput";
+import { InputCompletedToggle } from "./InputCompletedToggle";
 
 interface CalendarProps {
   currentMonth: Date;
@@ -12,6 +13,8 @@ interface CalendarProps {
   userId: string | null;
   participantName: string;
   onNameChange: (name: string) => void;
+  inputCompleted: boolean;
+  onInputCompletedChange: (completed: boolean) => void;
   isSaving: boolean;
   showSaveSuccess: boolean;
   saveError: string | null;
@@ -26,13 +29,17 @@ export function Calendar({
   userId,
   participantName,
   onNameChange,
+  inputCompleted,
+  onInputCompletedChange,
   isSaving,
   showSaveSuccess,
   saveError,
 }: CalendarProps) {
   return (
     <div className="bg-white rounded-xl shadow-lg p-6">
-      <ParticipantNameInput value={participantName} onChange={onNameChange} disabled={isSaving} />
+      <ParticipantNameInput value={participantName} onChange={onNameChange} disabled={isSaving || inputCompleted} />
+
+      <InputCompletedToggle checked={inputCompleted} onChange={onInputCompletedChange} disabled={isSaving} />
 
       <CalendarNavigation currentMonth={currentMonth} onMonthChange={onMonthChange} />
 
@@ -42,6 +49,7 @@ export function Calendar({
         onDateClick={onDateClick}
         getNGCountForDate={getNGCountForDate}
         userId={userId}
+        disabled={inputCompleted}
       />
 
       <CalendarStatus isSaving={isSaving} showSaveSuccess={showSaveSuccess} saveError={saveError} />

--- a/src/components/event/CalendarDay.tsx
+++ b/src/components/event/CalendarDay.tsx
@@ -7,6 +7,7 @@ interface CalendarDayProps {
   isPastDate: boolean;
   userId: string | null;
   onDateClick: (date: string) => void;
+  disabled?: boolean;
 }
 
 export function CalendarDay({
@@ -18,8 +19,9 @@ export function CalendarDay({
   isPastDate,
   userId,
   onDateClick,
+  disabled,
 }: CalendarDayProps) {
-  const isDisabled = !userId || isPastDate;
+  const isDisabled = !userId || isPastDate || disabled;
 
   return (
     <button

--- a/src/components/event/CalendarGrid.tsx
+++ b/src/components/event/CalendarGrid.tsx
@@ -7,6 +7,7 @@ interface CalendarGridProps {
   onDateClick: (date: string) => void;
   getNGCountForDate: (date: string) => number;
   userId: string | null;
+  disabled?: boolean;
 }
 
 export function CalendarGrid({
@@ -15,6 +16,7 @@ export function CalendarGrid({
   onDateClick,
   getNGCountForDate,
   userId,
+  disabled,
 }: CalendarGridProps) {
   const days = getDaysInMonth(currentMonth);
   const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
@@ -56,6 +58,7 @@ export function CalendarGrid({
             isPastDate={isPastDate}
             userId={userId}
             onDateClick={onDateClick}
+            disabled={disabled}
           />
         );
       })}

--- a/src/components/event/EventPage.tsx
+++ b/src/components/event/EventPage.tsx
@@ -37,6 +37,8 @@ export function EventPage({ event }: EventPageProps) {
           userId={eventState.userId}
           participantName={eventState.participantName}
           onNameChange={eventState.handleNameChange}
+          inputCompleted={eventState.inputCompleted}
+          onInputCompletedChange={eventState.handleInputCompletedChange}
           isSaving={eventState.isSaving}
           showSaveSuccess={eventState.showSaveSuccess}
           saveError={eventState.saveError}

--- a/src/components/event/EventSummary.tsx
+++ b/src/components/event/EventSummary.tsx
@@ -11,15 +11,15 @@ export function EventSummary({ event }: EventSummaryProps) {
   // 参加者リストを生成（名前順ソート、匿名参加者は「ななしさん」として採番）
   const participantsList = useMemo(() => {
     const participants = Object.entries(event.participants);
-    const namedParticipants: Array<{ name: string }> = [];
-    const anonymousParticipants: Array<{ id: string; order: number }> = [];
+    const namedParticipants: Array<{ name: string; inputCompleted: boolean }> = [];
+    const anonymousParticipants: Array<{ id: string; order: number; inputCompleted: boolean }> = [];
 
     // 名前ありと匿名を分類
     participants.forEach(([id, participant], index) => {
       if (participant.name) {
-        namedParticipants.push({ name: participant.name });
+        namedParticipants.push({ name: participant.name, inputCompleted: participant.inputCompleted ?? false });
       } else {
-        anonymousParticipants.push({ id, order: index });
+        anonymousParticipants.push({ id, order: index, inputCompleted: participant.inputCompleted ?? false });
       }
     });
 
@@ -30,13 +30,19 @@ export function EventSummary({ event }: EventSummaryProps) {
     const result = [
       ...namedParticipants.map((p) => ({
         displayName: p.name.length > 20 ? `${p.name.slice(0, 17)}...` : p.name,
+        inputCompleted: p.inputCompleted,
       })),
       ...anonymousParticipants.map((p, index) => ({
         displayName: anonymousParticipants.length === 1 ? "ななしさん" : `ななしさん${index + 1}`,
+        inputCompleted: p.inputCompleted,
       })),
     ];
 
     return result;
+  }, [event.participants]);
+
+  const inputInProgressCount = useMemo(() => {
+    return Object.values(event.participants).filter((p) => !p.inputCompleted).length;
   }, [event.participants]);
 
   return (
@@ -45,6 +51,7 @@ export function EventSummary({ event }: EventSummaryProps) {
       <div className="text-sm text-gray-600">
         <p>
           現在 <span className="font-bold text-gray-800">{participantCount}名</span> が参加中
+          {inputInProgressCount > 0 && <span className="text-gray-500">（{inputInProgressCount}名が入力中）</span>}
         </p>
         <p className="mt-2 text-xs text-gray-500">カレンダーの数字は、その日にNGな人数を表示しています</p>
 
@@ -53,8 +60,16 @@ export function EventSummary({ event }: EventSummaryProps) {
             <h3 className="font-semibold text-gray-700 mb-2">参加者一覧</h3>
             <ul className="space-y-1">
               {participantsList.map((participant) => (
-                <li key={participant.displayName} className="py-1 px-2 hover:bg-gray-50 rounded">
+                <li
+                  key={participant.displayName}
+                  className="py-1 px-2 hover:bg-gray-50 rounded flex items-center gap-2"
+                >
                   <span className="text-gray-700">{participant.displayName}</span>
+                  {participant.inputCompleted ? (
+                    <span className="text-xs px-1.5 py-0.5 rounded-full bg-green-100 text-green-700">入力できた</span>
+                  ) : (
+                    <span className="text-xs px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500">入力中</span>
+                  )}
                 </li>
               ))}
             </ul>

--- a/src/components/event/InputCompletedToggle.tsx
+++ b/src/components/event/InputCompletedToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+interface InputCompletedToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+export function InputCompletedToggle({ checked, onChange, disabled }: InputCompletedToggleProps) {
+  return (
+    <div className="mb-6">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          onClick={() => onChange(!checked)}
+          disabled={disabled}
+          className={`
+            relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent
+            transition-colors duration-200 ease-in-out
+            focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2
+            ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}
+            ${checked ? "bg-red-500" : "bg-gray-200"}
+          `}
+        >
+          <span
+            className={`
+              pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow
+              transform transition duration-200 ease-in-out
+              ${checked ? "translate-x-5" : "translate-x-0"}
+            `}
+          />
+        </button>
+        <span className={`text-sm font-medium ${checked ? "text-red-600" : "text-gray-700"}`}>入力できた</span>
+      </div>
+      {!checked && (
+        <p className="mt-2 text-xs text-gray-500">こちらをONにしておくと他の参加者に入力が終わったことを伝えられます</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/event/InputCompletedToggle.tsx
+++ b/src/components/event/InputCompletedToggle.tsx
@@ -34,9 +34,7 @@ export function InputCompletedToggle({ checked, onChange, disabled }: InputCompl
         </button>
         <span className={`text-sm font-medium ${checked ? "text-red-600" : "text-gray-700"}`}>入力できた</span>
       </div>
-      {!checked && (
-        <p className="mt-2 text-xs text-gray-500">こちらをONにしておくと他の参加者に入力が終わったことを伝えられます</p>
-      )}
+      <p className="mt-2 text-xs text-gray-500">こちらをONにしておくと他の参加者に入力が終わったことを伝えられます</p>
     </div>
   );
 }

--- a/src/components/event/__tests__/EventPage.test.tsx
+++ b/src/components/event/__tests__/EventPage.test.tsx
@@ -9,11 +9,13 @@ vi.mock("@/hooks/useEventState", () => ({
     userId: "test-user-id",
     selectedDates: new Set(["2024-01-15"]),
     participantName: "",
+    inputCompleted: false,
     isSaving: false,
     showSaveSuccess: false,
     saveError: null,
     handleDateClick: vi.fn(),
     handleNameChange: vi.fn(),
+    handleInputCompletedChange: vi.fn(),
     getNGCountForDate: vi.fn(() => 0),
   })),
 }));
@@ -72,10 +74,10 @@ describe("EventPage", () => {
     expect(screen.getByText("集計")).toBeInTheDocument();
     expect(screen.getByText("2名")).toBeInTheDocument(); // 2 participants
 
-    // Use partial text matching for the compound text
+    // Use partial text matching for the compound text (includes input progress count)
     expect(
       screen.getByText((_content, element) => {
-        return element?.textContent === "現在 2名 が参加中";
+        return element?.textContent === "現在 2名 が参加中（2名が入力中）";
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/event/__tests__/EventSummary.test.tsx
+++ b/src/components/event/__tests__/EventSummary.test.tsx
@@ -21,10 +21,10 @@ describe("EventSummary", () => {
     expect(screen.getByText("集計")).toBeInTheDocument();
     expect(screen.getByText("3名")).toBeInTheDocument();
 
-    // Check the full text content
+    // Check the full text content (includes input progress count)
     expect(
       screen.getByText((_, element) => {
-        return element?.textContent === "現在 3名 が参加中";
+        return element?.textContent === "現在 3名 が参加中（3名が入力中）";
       }),
     ).toBeInTheDocument();
   });

--- a/src/components/event/__tests__/ParticipantNameInput.test.tsx
+++ b/src/components/event/__tests__/ParticipantNameInput.test.tsx
@@ -84,7 +84,7 @@ describe("ParticipantNameInput", () => {
   });
 
   it("should handle undefined value prop", () => {
-    // @ts-ignore - testing edge case
+    // @ts-expect-error - testing edge case
     render(<ParticipantNameInput onChange={mockOnChange} />);
 
     const input = screen.getByRole("textbox");

--- a/src/services/__tests__/participantService.test.ts
+++ b/src/services/__tests__/participantService.test.ts
@@ -51,6 +51,7 @@ describe("participantService", () => {
             user123: {
               ng_dates: ["2024-01-15", "2024-01-16"],
               name: "田中太郎",
+              inputCompleted: false,
             },
           },
         }),
@@ -72,6 +73,7 @@ describe("participantService", () => {
             user123: {
               ng_dates: ["2024-01-15"],
               name: undefined,
+              inputCompleted: false,
             },
           },
         }),
@@ -105,6 +107,7 @@ describe("participantService", () => {
             newUser: {
               ng_dates: ["2024-01-15"],
               name: "新規ユーザー",
+              inputCompleted: false,
             },
           },
         }),

--- a/src/services/participantService.ts
+++ b/src/services/participantService.ts
@@ -14,6 +14,7 @@ export async function updateParticipant(
   userId: string,
   ngDates: string[],
   name?: string,
+  inputCompleted?: boolean,
 ): Promise<UpdateParticipantResult> {
   try {
     // バリデーション
@@ -34,6 +35,7 @@ export async function updateParticipant(
         event.participants[userId] = {
           ng_dates: ngDates,
           name: validatedName,
+          inputCompleted: inputCompleted ?? false,
         };
 
         // 保存（TTLをリセット）

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,6 +1,7 @@
 export interface Participant {
   ng_dates: string[];
   name?: string;
+  inputCompleted?: boolean;
 }
 
 export interface Event {


### PR DESCRIPTION
## Summary
This PR adds the ability for participants to mark their input as complete in the event scheduling interface. When enabled, participants can toggle an "入力できた" (input completed) status, which prevents further calendar modifications and displays their completion status to other participants.

## Key Changes

- **New Component**: `InputCompletedToggle` - A toggle switch allowing participants to mark their input as complete
- **State Management**: Added `inputCompleted` state to `useEventState` hook with persistence to the database
- **UI Updates**:
  - Calendar dates become disabled when a participant marks input as complete
  - Participant name input is disabled when input is marked complete
  - Event summary now displays completion status badges ("入力できた" / "入力中") for each participant
  - Shows count of participants still in progress
- **Data Model**: Extended `Participant` interface with optional `inputCompleted` boolean field
- **API Layer**: Updated `updateParticipant` action and service to accept and persist the `inputCompleted` flag
- **Accessibility**: Toggle switch includes proper ARIA attributes and keyboard focus management

## Implementation Details

- The completion status is automatically saved to the database when toggled
- Existing participants have their completion status restored on page load
- The toggle is disabled during save operations to prevent race conditions
- Completion status is displayed with color-coded badges (green for complete, gray for in-progress)
- Tests updated to reflect the new participant list structure with completion status

https://claude.ai/code/session_01QzPoarrZMgEobeJiqKtraU